### PR TITLE
feat: tappable source links + persist collapse/scroll state (#27)

### DIFF
--- a/app/topic/[id].tsx
+++ b/app/topic/[id].tsx
@@ -33,8 +33,9 @@ export default function ExplorerScreen() {
     expandedNodes,
     toggleNode,
     setExpandedNodes,
+    loaded: collapseStateLoaded,
   } = usePersistedCollapseState(id, new Set());
-  const { scrollRef, onScroll, restoreScrollPosition } = usePersistedScrollPosition(id);
+  const { scrollRef, onScroll, onContentSizeChange } = usePersistedScrollPosition(id);
 
   useEffect(() => {
     if (!id) return;
@@ -50,19 +51,6 @@ export default function ExplorerScreen() {
         if (cancelled) return;
         const rootTree = buildTree(data.nodes);
         setTree(rootTree);
-
-        // Only set default expansion if no persisted state was loaded
-        if (expandedNodes.size === 0) {
-          const expanded = new Set<string>();
-          expanded.add(rootTree.id);
-          for (const child of rootTree.children) {
-            expanded.add(child.id);
-          }
-          setExpandedNodes(expanded);
-        }
-
-        // Restore scroll position after tree renders
-        setTimeout(() => restoreScrollPosition(), 200);
       } catch (e) {
         if (cancelled) return;
         if (e instanceof NotFoundError) {
@@ -78,8 +66,21 @@ export default function ExplorerScreen() {
 
     load();
     return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-fetch on id/retry, not on collapse state changes
   }, [id, retryCount]);
+
+  // Apply default expansion once tree + collapse state are both loaded
+  useEffect(() => {
+    if (!tree || !collapseStateLoaded) return;
+    if (expandedNodes.size === 0) {
+      const expanded = new Set<string>();
+      expanded.add(tree.id);
+      for (const child of tree.children) {
+        expanded.add(child.id);
+      }
+      setExpandedNodes(expanded);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when tree or loaded changes
+  }, [tree, collapseStateLoaded]);
 
   // toggleNode comes from usePersistedCollapseState hook
 
@@ -229,6 +230,7 @@ export default function ExplorerScreen() {
       <ScrollView
         ref={scrollRef}
         onScroll={onScroll}
+        onContentSizeChange={onContentSizeChange}
         scrollEventThrottle={100}
         contentContainerStyle={styles.scrollContent}
       >

--- a/components/CollapsibleSection/CollapsibleSection.tsx
+++ b/components/CollapsibleSection/CollapsibleSection.tsx
@@ -248,7 +248,13 @@ function CollapsibleSectionInner({
                 <Pressable
                   key={i}
                   testID={`source-link-${nodeId}-${i}`}
-                  onPress={() => source.url && Linking.openURL(source.url)}
+                  onPress={() => {
+                    if (source.url) {
+                      Linking.openURL(source.url).catch(() => {
+                        Alert.alert('Cannot open link', 'This link could not be opened.');
+                      });
+                    }
+                  }}
                   accessibilityRole="link"
                   accessibilityLabel={`Open ${source.title}`}
                 >

--- a/hooks/usePersistedCollapseState.ts
+++ b/hooks/usePersistedCollapseState.ts
@@ -5,7 +5,6 @@ const DEBOUNCE_MS = 500;
 
 /**
  * Manages collapse state for a topic, persisted to AsyncStorage.
- * Returns [expandedNodes, toggleNode, setExpandedNodes].
  */
 export function usePersistedCollapseState(
   topicId: string | undefined,
@@ -14,6 +13,8 @@ export function usePersistedCollapseState(
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(defaultExpanded);
   const [loaded, setLoaded] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const expandedRef = useRef(expandedNodes);
+  expandedRef.current = expandedNodes;
 
   // Load persisted state
   useEffect(() => {
@@ -28,13 +29,15 @@ export function usePersistedCollapseState(
             if (Array.isArray(ids)) {
               setExpandedNodes(new Set(ids));
             }
-          } catch {
-            // Corrupt data — use defaults
+          } catch (e) {
+            console.warn(`[collapseState] Corrupt data for ${topicId}, clearing:`, e);
+            AsyncStorage.removeItem(key).catch(() => {});
           }
         }
         setLoaded(true);
       })
-      .catch(() => {
+      .catch((e) => {
+        console.warn(`[collapseState] Failed to load for ${topicId}:`, e);
         setLoaded(true);
       });
   }, [topicId]);
@@ -47,12 +50,18 @@ export function usePersistedCollapseState(
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
       AsyncStorage.setItem(key, JSON.stringify(Array.from(expandedNodes))).catch(
-        () => {} // Best-effort save
+        (e) => console.warn(`[collapseState] Failed to save for ${topicId}:`, e)
       );
     }, DEBOUNCE_MS);
 
     return () => {
       if (saveTimer.current) clearTimeout(saveTimer.current);
+      // Flush current state on unmount
+      if (topicId && loaded) {
+        AsyncStorage.setItem(key, JSON.stringify(Array.from(expandedRef.current))).catch(
+          (e) => console.warn(`[collapseState] Failed to flush on unmount:`, e)
+        );
+      }
     };
   }, [expandedNodes, topicId, loaded]);
 

--- a/hooks/usePersistedScrollPosition.ts
+++ b/hooks/usePersistedScrollPosition.ts
@@ -4,20 +4,38 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 /**
  * Persists and restores scroll position for a topic.
+ * Use onContentSizeChange on ScrollView to trigger restore.
  */
 export function usePersistedScrollPosition(topicId: string | undefined) {
   const scrollRef = useRef<ScrollView>(null);
   const scrollY = useRef(0);
   const restored = useRef(false);
+  const targetY = useRef<number | null>(null);
 
-  // Save on unmount
+  // Load target Y on mount
   useEffect(() => {
+    restored.current = false;
+    targetY.current = null;
+    if (!topicId) return;
+
+    AsyncStorage.getItem(`scroll-pos:${topicId}`)
+      .then((raw) => {
+        if (raw) {
+          const y = parseInt(raw, 10);
+          if (!isNaN(y) && y > 0) {
+            targetY.current = y;
+          }
+        }
+      })
+      .catch((e) => console.warn(`[scrollPosition] Failed to load for ${topicId}:`, e));
+
+    // Save on unmount
     return () => {
       if (topicId && scrollY.current > 0) {
         AsyncStorage.setItem(
           `scroll-pos:${topicId}`,
           String(Math.round(scrollY.current)),
-        ).catch(() => {});
+        ).catch((e) => console.warn(`[scrollPosition] Failed to save for ${topicId}:`, e));
       }
     };
   }, [topicId]);
@@ -26,24 +44,12 @@ export function usePersistedScrollPosition(topicId: string | undefined) {
     scrollY.current = e.nativeEvent.contentOffset.y;
   }, []);
 
-  const restoreScrollPosition = useCallback(() => {
-    if (!topicId || restored.current) return;
+  // Called by ScrollView's onContentSizeChange — content is laid out
+  const onContentSizeChange = useCallback(() => {
+    if (restored.current || targetY.current === null) return;
     restored.current = true;
+    scrollRef.current?.scrollTo({ y: targetY.current, animated: false });
+  }, []);
 
-    AsyncStorage.getItem(`scroll-pos:${topicId}`)
-      .then((raw) => {
-        if (raw) {
-          const y = parseInt(raw, 10);
-          if (!isNaN(y) && y > 0) {
-            // Small delay to let content render
-            setTimeout(() => {
-              scrollRef.current?.scrollTo({ y, animated: false });
-            }, 100);
-          }
-        }
-      })
-      .catch(() => {});
-  }, [topicId]);
-
-  return { scrollRef, onScroll, restoreScrollPosition };
+  return { scrollRef, onScroll, onContentSizeChange };
 }


### PR DESCRIPTION
## Description

Two Explorer UX improvements:

1. **Tappable source links** — Source URLs now open in the device browser when tapped
2. **Persist collapse/scroll state** — Collapse state and scroll position saved to AsyncStorage per topic

Closes #27

## Changes

- `CollapsibleSection.tsx` — Source links wrapped in `Pressable` with `Linking.openURL`, accessibilityRole="link"
- `hooks/usePersistedCollapseState.ts` — Custom hook: saves/restores expanded node IDs via AsyncStorage with 500ms debounce
- `hooks/usePersistedScrollPosition.ts` — Custom hook: saves scroll Y on unmount, restores after tree renders
- `app/topic/[id].tsx` — Wired both hooks, removed inline toggleNode (now from hook), ScrollView ref + onScroll

## Test plan
- [x] TypeScript compiles
- [x] ESLint passes
- [ ] Tap source link → opens URL in browser
- [ ] Navigate away from topic, return → collapse state preserved
- [ ] Navigate away, return → scroll position restored
- [ ] First visit to a topic → defaults (H1+H2 expanded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)